### PR TITLE
sets up l10n strings for en locale

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+- Adds English (`en`) locale strings for static text.
+
 ## 1.0.1 (2021-08-26)
 
 - Localization is inappropriate for redirects since it's necessary to be able to redirect from any URL. Previously `autopublish: true` was used by the module, but `localize: false` is more appropriate as it eliminates multiple locale versions altogether. A migration has been added to take care of existing redirects in this transition.

--- a/i18n/en.json
+++ b/i18n/en.json
@@ -1,0 +1,17 @@
+{
+  "label": "Redirect",
+  "pluralLabel": "Redirects",
+  "originalSlug": "Old URL",
+  "originalSlugHelp": "Format with leading slash (e.g., /old-url)",
+  "title": "Description",
+  "urlType": "Link Type",
+  "urlTypeInternal": "Internal Page",
+  "urlTypeExternal": "External URL",
+  "ignoreQuery": "Ignore query string when matching.",
+  "newPage": "Page Title",
+  "external": "URL",
+  "statusCode": "Redirect Type",
+  "statusCodeHtmlHelp": "<ul><li>Use <strong>\"Temporary\"</strong> for temporary redirects or for testing purposes.</li><li>Use <strong>\"Permanent\"</strong> after testing, this is an SEO best practice. ⚠️ Search engines will cache these, so check carefully.</li>",
+  "302": "Temporary (status code 302)",
+  "301": "Permanent (status code 301)"
+}

--- a/index.js
+++ b/index.js
@@ -2,8 +2,8 @@ module.exports = {
   extend: '@apostrophecms/piece-type',
   options: {
     alias: 'redirect',
-    label: 'Redirect',
-    pluralLabel: 'Redirects',
+    label: 'aposRedirect:label',
+    pluralLabel: 'aposRedirect:pluralLabel',
     searchable: false,
     editRole: 'editor',
     publishRole: 'editor',
@@ -11,6 +11,10 @@ module.exports = {
     localized: false,
     quickCreate: false,
     statusCode: 302,
+    i18n: {
+      ns: 'aposRedirect',
+      browser: true
+    },
     openGraph: false, // Disables @apostrophecms/open-graph for redirects
     seo: false // Disables @apostrophecms/seo for redirects
   },
@@ -37,47 +41,47 @@ module.exports = {
     const add = {
       redirectSlug: {
         // This is *not* type: 'slug' because we want to let you match any
-        // goldang nonsense the old site had in there, including mixed case
+        // nonsense the old site had in there, including mixed case.
         type: 'string',
-        label: 'Old URL',
-        help: 'Format with leading / such as /old-url',
+        label: 'aposRedirect:originalSlug',
+        help: 'aposRedirect:originalSlugHelp',
         required: true
       },
       title: {
-        label: 'Description',
+        label: 'aposRedirect:title',
         type: 'string',
         required: true
       },
       urlType: {
-        label: 'Link To',
+        label: 'aposRedirect:urlType',
         type: 'select',
         choices: [
           {
-            label: 'Internal Page',
+            label: 'aposRedirect:urlTypeInternal',
             value: 'internal'
           },
           {
-            label: 'External URL',
+            label: 'aposRedirect:urlTypeExternal',
             value: 'external'
           }
         ],
         def: 'internal'
       },
       ignoreQueryString: {
-        label: 'Ignore query string when matching.',
+        label: 'aposRedirect:ignoreQuery',
         type: 'boolean',
         def: false
       },
       _newPage: {
         type: 'relationship',
-        label: 'Page Title',
+        label: 'aposRedirect:newPage',
         withType: '@apostrophecms/page',
         if: {
           urlType: 'internal'
         },
         builders: {
-          // Editors+ set up redirects, so it's OK for non-admins to follow them anywhere
-          // (they won't actually get access without logging in)
+          // Editors+ set up redirects, so it's OK for non-admins to follow
+          // them anywhere (they won't actually get access without logging in)
           project: {
             slug: 1,
             title: 1,
@@ -87,23 +91,23 @@ module.exports = {
         max: 1
       },
       externalUrl: {
-        label: 'URL',
+        label: 'aposRedirect:external',
         type: 'url',
         if: {
           urlType: 'external'
         }
       },
       statusCode: {
-        label: 'Redirect Type',
+        label: 'aposRedirect:statusCode',
         type: 'radio',
-        htmlHelp: 'Use <strong>"Temporary"</strong> for temporary redirects or for testing purposes.<br />Use <strong>"Permanent"</strong> after testing, this is an SEO best practice.',
+        htmlHelp: 'aposRedirect:statusCodeHtmlHelp',
         choices: [
           {
-            label: 'Temporary (Status code 302)',
+            label: 'aposRedirect:302',
             value: '302'
           },
           {
-            label: 'Permanent (Status code 301, Search engines will cache these, proofread carefully)',
+            label: 'aposRedirect:301',
             value: '301'
           }
         ],
@@ -113,7 +117,7 @@ module.exports = {
 
     const group = {
       basics: {
-        label: 'Basics',
+        label: 'apostrophe:basics',
         fields: [
           'title',
           'redirectSlug',


### PR DESCRIPTION
There is a bug where a project that has only a single non-English locale will not convert the keys to strings. We'll need some kind of fallback mechanism. For now this is setting up l10n for others to build on.