### PR TITLE
Check url with locale prefixes and compare with redirectSlug

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## Unreleased
 
-- Fixes redirections when using locales prefixes. The locale prefix must be added to the `redirectSlug` to avoid conflicts with other locales.
+- Fixes redirections when using locale prefixes. The locale prefix must be added to the `redirectSlug` to avoid conflicts with other locales.
 
 ## 1.2.2 (2023-03-06)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Fixes redirections when using locales prefixes. The locale prefix must be added to the `redirectSlug` to avoid conflicts with other locales.
+
 ## 1.2.2 (2023-03-06)
 
 - Removes `apostrophe` as a peer dependency.

--- a/index.js
+++ b/index.js
@@ -147,9 +147,8 @@ module.exports = {
       async checkRedirect(req, res, next) {
         try {
           const slug = req.originalUrl;
-          const pathOnly = slug.split('?')[0];
-          const redirectRegEx = new RegExp(`^redirect-${self.apos.util.regExpQuote(pathOnly)}(\\?.*)?$`);
-          const results = await self.find(req, { slug: redirectRegEx }).toArray();
+          const [ pathOnly ] = slug.split('?');
+          const results = await self.find(req, { redirectSlug: pathOnly }).toArray();
 
           if (!results || !results.length) {
             return await emitAndRedirectOrNext();

--- a/index.js
+++ b/index.js
@@ -150,6 +150,7 @@ module.exports = {
           const pathOnly = slug.split('?')[0];
           const redirectRegEx = new RegExp(`^redirect-${self.apos.util.regExpQuote(pathOnly)}(\\?.*)?$`);
           const results = await self.find(req, { slug: redirectRegEx }).toArray();
+
           if (!results || !results.length) {
             return await emitAndRedirectOrNext();
           }
@@ -165,7 +166,7 @@ module.exports = {
           const status = (parsedCode && !isNaN(parsedCode)) ? parsedCode : 302;
 
           if (target.urlType === 'internal' && target._newPage && target._newPage[0]) {
-            return req.res.redirect(status, target.redirectSlug);
+            return req.res.redirect(status, target._newPage[0].slug);
           } else if (target.urlType === 'external' && target.externalUrl.length) {
             return req.res.redirect(status, target.externalUrl);
           }

--- a/index.js
+++ b/index.js
@@ -169,9 +169,8 @@ module.exports = {
 
           const parsedCode = parseInt(target.statusCode);
           const status = (parsedCode && !isNaN(parsedCode)) ? parsedCode : 302;
-
           if (target.urlType === 'internal' && target._newPage && target._newPage[0]) {
-            return req.res.rawRedirect(status, target._newPage[0].slug);
+            return req.res.rawRedirect(status, target._newPage[0]._url);
           } else if (target.urlType === 'external' && target.externalUrl.length) {
             return req.res.rawRedirect(status, target.externalUrl);
           }

--- a/index.js
+++ b/index.js
@@ -148,9 +148,9 @@ module.exports = {
         try {
           const slug = req.originalUrl;
           const [ pathOnly ] = slug.split('?');
-          const results = await self.find(req, { redirectSlug: pathOnly }).toArray();
+          const results = await self.find(req, { $or: [ { redirectSlug: slug }, { redirectSlug: pathOnly } ] }).toArray();
 
-          if (!results || !results.length) {
+          if (!results.length) {
             return await emitAndRedirectOrNext();
           }
 

--- a/index.js
+++ b/index.js
@@ -146,34 +146,30 @@ module.exports = {
     return {
       async checkRedirect(req, res, next) {
         try {
-          const slug = req.url;
+          const slug = req.originalUrl;
           const pathOnly = slug.split('?')[0];
           const redirectRegEx = new RegExp(`^redirect-${self.apos.util.regExpQuote(pathOnly)}(\\?.*)?$`);
           const results = await self.find(req, { slug: redirectRegEx }).toArray();
-          let target;
-          if (results) {
-            if (results.some(result => result.redirectSlug === slug)) {
-              target = results.find(result => result.redirectSlug === slug);
-            } else if (results.some(result => result.redirectSlug === pathOnly && result.ignoreQueryString)) {
-              target = results.find(result => result.redirectSlug === pathOnly && result.ignoreQueryString);
-            }
-
-            if (target) {
-              let status = parseInt(target.statusCode);
-
-              if (isNaN(status) || !status) {
-                status = 302;
-              }
-
-              if (target.urlType === 'internal' && target._newPage && target._newPage[0]) {
-                return req.res.redirect(status, target._newPage[0]._url);
-              } else if (target.urlType === 'external' && target.externalUrl.length) {
-                return req.res.redirect(status, target.externalUrl);
-              } else {
-                return await emitAndRedirectOrNext();
-              }
-            }
+          if (!results || !results.length) {
+            return await emitAndRedirectOrNext();
           }
+
+          const target = results.find(({ redirectSlug }) => redirectSlug === slug) ||
+           results.find(({ redirectSlug, ignoreQueryString }) => redirectSlug === pathOnly && ignoreQueryString);
+
+          if (!target) {
+            return await emitAndRedirectOrNext();
+          }
+
+          const parsedCode = parseInt(target.statusCode);
+          const status = (parsedCode && !isNaN(parsedCode)) ? parsedCode : 302;
+
+          if (target.urlType === 'internal' && target._newPage && target._newPage[0]) {
+            return req.res.redirect(status, target.redirectSlug);
+          } else if (target.urlType === 'external' && target.externalUrl.length) {
+            return req.res.redirect(status, target.externalUrl);
+          }
+
           return await emitAndRedirectOrNext();
         } catch (e) {
           self.apos.util.error(e);


### PR DESCRIPTION
[PRO-4495](https://linear.app/apostrophecms/issue/PRO-4495/the-redirect-module-checks-the-slug-property-of-the-redirect-piece)
[PRO-4493](https://linear.app/apostrophecms/issue/PRO-4493/redirectlocalization-issues-prefixes-are-removed-before-consulting)

## Summary
* Modifies the middleware to check the `originalUrl` instead of `url` in which the locale prefix has been removed.
* Removes the regex and performs a `$or` request on redirect pieces `redirectSlug` property because there was issues when using the slug since this one can be modified by the server for de duplication for example.
* When redirecting to internal pages, use the page piece `slug` property instead of the `_url` of the new page to avoid being redirected on pages like `/fr/fr/page`.

## What are the specific steps to test this change?

On project with multiple locales using prefixes, when creating a new redirection, you must specify the locale prefix, it allows to avoid conflicts with potential pieces with the same slug in other locales.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
