### PR TITLE
Pro 4691 redirect to other locales

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,45 @@
+# This is a basic workflow to help you get started with Actions
+
+name: tests
+
+# Controls when the action will run.
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ '*' ]
+
+  # Allows you to run this workflow manually from the Actions tab
+  workflow_dispatch:
+
+# A workflow run is made up of one or more jobs that can run sequentially or in parallel
+jobs:
+  # This workflow contains a single job called "build"
+  build:
+    # The type of runner that the job will run on
+    runs-on: ubuntu-latest
+    strategy:
+      matrix:
+        node-version: [18, 20]
+        mongodb-version: ['4.4', '5.0', '6.0']
+
+    # Steps represent a sequence of tasks that will be executed as part of the job
+    steps:
+    - name: Git checkout
+      uses: actions/checkout@v3
+
+    - name: Use Node.js ${{ matrix.node-version }}
+      uses: actions/setup-node@v3
+      with:
+        node-version: ${{ matrix.node-version }}
+
+    - name: Start MongoDB
+      uses: supercharge/mongodb-github-action@1.8.0
+      with:
+        mongodb-version: ${{ matrix.mongodb-version }}
+
+    - run: npm install
+
+    - run: npm test
+      env:
+        CI: true

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## Unreleased
+
+- Adds possibility to redirect from a locale to another one using internal redirects.
+
 ## 1.2.3
 
 - Fixes redirections when using locale prefixes.

--- a/README.md
+++ b/README.md
@@ -114,3 +114,20 @@ module.exports = {
   }
 };
 ```
+
+
+## Redirecting to other locales
+
+It's possible to redirect from a locale to another one, with external redirections, 
+since you define manually the url to redirect to.
+
+But also with internal redirects (relationship to page), even if relationships don't support relationships to other locales.
+
+A query builder exist called `currentLocaleTarget` that hide redirects that have relationships to other locales (different from the current one).
+If you want to get all redirects whatever the locale of their internal redirects you can undo this behavior using the query builder:
+```javascript
+const redirects = await self.apos.modules['@apostrophecms/redirect']
+    .find(req)
+    .currentLocaleTarget(false)
+    .toArray();
+```

--- a/README.md
+++ b/README.md
@@ -118,12 +118,14 @@ module.exports = {
 
 ## Redirecting to other locales
 
-It's possible to redirect from a locale to another one, with external redirections, 
-since you define manually the url to redirect to.
+It's possible to redirect from one locale to another one, with external redirections, 
+since you manually define the url to redirect to.
 
-But also with internal redirects (relationship to page), even if relationships don't support relationships to other locales.
+As for internal redirects (relationships with pages), this works across locales as well, 
+but keep in mind that you will only see the internal redirects that target the current locale when managing redirects. 
+To find redirects that target an internal page in a different locale, switch locales before viewing "Manage Redirects."
 
-A query builder exist called `currentLocaleTarget` that hide redirects that have relationships to other locales (different from the current one).
+A note for developers: a query builder called `currentLocaleTarget` hides redirects that have relationships to other locales (different from the current one).
 If you want to get all redirects whatever the locale of their internal redirects you can undo this behavior using the query builder:
 ```javascript
 const redirects = await self.apos.modules['@apostrophecms/redirect']

--- a/index.js
+++ b/index.js
@@ -222,17 +222,19 @@ module.exports = {
   queries(self, query) {
     return {
       builders: {
-        withLocaleTarget: {
-          launder(locale) {
-            console.log('locale', locale);
-            return self.apos.launder.string(locale);
+        def: true,
+        currentLocaleTarget: {
+          launder(val) {
+            return self.apos.launder.booleanOrNull(val);
           },
-          def: null,
           finalize() {
-            const locale = query.get('withLocaleTarget');
-            return query.and({ $or: [ { targetLocale: null }, { targetLocale: locale } ] });
-          }
+            const active = query.get('currentLocaleTarget');
+            const locale = query.req.locale;
 
+            if (active && locale) {
+              query.and({ $or: [ { targetLocale: null }, { targetLocale: locale } ] });
+            }
+          }
         }
       }
     };
@@ -261,14 +263,6 @@ module.exports = {
       },
       createIndexes() {
         self.apos.doc.db.createIndex({ redirectSlug: 1 });
-      }
-    };
-  },
-
-  extendMethods(self) {
-    return {
-      find(_super, req, criteria, options) {
-        return _super(req, criteria, options).withLocaleTarget(req.locale);
       }
     };
   }

--- a/index.js
+++ b/index.js
@@ -222,14 +222,14 @@ module.exports = {
   queries(self, query) {
     return {
       builders: {
-        def: true,
         currentLocaleTarget: {
+          def: true,
           launder(val) {
             return self.apos.launder.booleanOrNull(val);
           },
           finalize() {
             const active = query.get('currentLocaleTarget');
-            const locale = query.req.locale;
+            const { locale } = query.req;
 
             if (active && locale) {
               query.and({ $or: [ { targetLocale: null }, { targetLocale: locale } ] });

--- a/index.js
+++ b/index.js
@@ -31,6 +31,13 @@ module.exports = {
           if (!doc.title) {
             doc.title = doc.redirectSlug;
           }
+        },
+        setCurrentLocale(req, doc) {
+          const internalPage = doc._newPage && doc._newPage[0];
+
+          if (internalPage && doc.urlType === 'internal') {
+            doc.targetLocale = internalPage.aposLocale.replace(/:.*$/, '');
+          }
         }
       }
     };
@@ -135,7 +142,7 @@ module.exports = {
       add.statusCode.def = options.statusCode.toString();
     }
 
-    add._newPage.withType = self.options.withType;
+    add._newPage.withType = options.withType;
 
     return {
       add,

--- a/index.js
+++ b/index.js
@@ -159,6 +159,7 @@ module.exports = {
 
           const results = await self
             .find(req, { $or: [ { redirectSlug: slug }, { redirectSlug: pathOnly } ] })
+            .currentLocaleTarget(false)
             .relationships(false)
             .project({
               _id: 1,

--- a/package.json
+++ b/package.json
@@ -16,6 +16,7 @@
   "author": "Apostrophe Technologies",
   "license": "MIT",
   "devDependencies": {
+    "apostrophe": "github:apostrophecms/apostrophe",
     "eslint": "^7.9.0",
     "eslint-config-apostrophe": "^3.4.0",
     "eslint-config-standard": "^14.1.1",

--- a/package.json
+++ b/package.json
@@ -6,7 +6,7 @@
   "scripts": {
     "lint": "npm run eslint",
     "eslint": "eslint .",
-    "test": "npm run lint"
+    "test": "npm run lint && mocha"
   },
   "repository": {
     "type": "git",
@@ -22,6 +22,7 @@
     "eslint-plugin-import": "^2.22.0",
     "eslint-plugin-node": "^11.1.0",
     "eslint-plugin-promise": "^4.2.1",
-    "eslint-plugin-standard": "^4.0.1"
+    "eslint-plugin-standard": "^4.0.1",
+    "mocha": "^10.2.0"
   }
 }

--- a/test/index.js
+++ b/test/index.js
@@ -1,0 +1,144 @@
+const assert = require('assert').strict;
+const t = require('apostrophe/test-lib/util.js');
+
+describe('@apostrophecms/redirect', function () {
+  let apos;
+  let redirectModule;
+
+  this.timeout(t.timeout);
+
+  after(async function() {
+    await t.destroy(apos);
+  });
+
+  before(async function() {
+    apos = await t.create({
+      root: module,
+      testModule: true,
+      modules: getAppConfig()
+    });
+
+    redirectModule = apos.modules['@apostrophecms/redirect'];
+    await insertPages(apos);
+  });
+
+  this.afterEach(async function() {
+    await apos.doc.db.deleteMany({ type: '@apostrophecms/redirect' });
+  });
+
+  it('should allow to redirect to external URLs', async function() {
+    const req = apos.task.getReq();
+    const instance = redirectModule.newInstance();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'external redirect',
+      urlType: 'external',
+      redirectSlug: '/page-1',
+      externalUrl: 'http://localhost:3000/page-2'
+    });
+    const redirected = await apos.http.get('http://localhost:3000/page-1');
+
+    assert.equal(redirected, '<title>page 2</title>\n');
+  });
+
+  it('should allow to redirect to internal pages', async function() {
+    const req = apos.task.getReq();
+    const instance = redirectModule.newInstance();
+    const page2 = await apos.page.find(req, { title: 'page 2' }).toObject();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'internal redirect',
+      urlType: 'internal',
+      redirectSlug: '/page-1',
+      _newPage: [ page2 ]
+    });
+    const redirected = await apos.http.get('http://localhost:3000/page-1');
+
+    assert.equal(redirected, '<title>page 2</title>\n');
+  });
+
+  it('should allow to redirect to internal pages in other locales', async function() {
+    const req = apos.task.getReq();
+    const reqFr = apos.task.getReq({ locale: 'fr' });
+    const instance = redirectModule.newInstance();
+    const pageFr = await apos.page.find(reqFr, { title: 'page fr' }).toObject();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'internal redirect',
+      urlType: 'internal',
+      redirectSlug: '/page-1',
+      _newPage: [ pageFr ]
+    });
+
+    const redirected = await apos.http.get('http://localhost:3000/page-1');
+    assert.equal(redirected, '<title>page fr</title>\n');
+  });
+});
+
+async function insertPages(apos) {
+  const req = apos.task.getReq();
+  const frReq = apos.task.getReq({ locale: 'fr' });
+  const defaultPageModule = apos.modules['default-page'];
+  const pageInstance = defaultPageModule.newInstance();
+
+  await apos.page.insert(req, '_home', 'lastChild', {
+    ...pageInstance,
+    title: 'page 1',
+    slug: '/page-1'
+  });
+  await apos.page.insert(req, '_home', 'lastChild', {
+    ...pageInstance,
+    title: 'page 2',
+    slug: '/page-2'
+  });
+  await apos.page.insert(frReq, '_home', 'lastChild', {
+    ...pageInstance,
+    title: 'page fr',
+    slug: '/page-fr'
+  });
+}
+
+function getAppConfig() {
+  return {
+    '@apostrophecms/express': {
+      options: {
+        session: { secret: 'supersecret' },
+        port: 3000
+      }
+    },
+    '@apostrophecms/i18n': {
+      options: {
+        defaultLocale: 'en',
+        locales: {
+          en: { label: 'English' },
+          fr: {
+            label: 'French',
+            prefix: '/fr'
+          }
+        }
+      }
+    },
+    '@apostrophecms/redirect': {},
+    'default-page': {},
+    article: {
+      extend: '@apostrophecms/piece-type',
+      options: {
+        alias: 'article'
+      }
+    },
+    topic: {
+      extend: '@apostrophecms/piece-type',
+      options: {
+        alias: 'topic'
+      },
+      fields: {
+        add: {
+          description: {
+            label: 'Description',
+            type: 'string'
+          }
+        }
+      }
+    }
+  };
+}

--- a/test/modules/default-page/index.js
+++ b/test/modules/default-page/index.js
@@ -1,0 +1,3 @@
+module.exports = {
+  extend: '@apostrophecms/page-type'
+};

--- a/test/modules/default-page/views/page.html
+++ b/test/modules/default-page/views/page.html
@@ -1,0 +1,1 @@
+<title>{{ data.page.title }}</title>

--- a/test/package.json
+++ b/test/package.json
@@ -1,0 +1,9 @@
+{
+  "/**": "This package.json file is not actually installed.",
+  " * ": "Apostrophe requires that all npm modules to be loaded by moog",
+  " */": "exist in package.json at project level, which for a test is here",
+  "dependencies": {
+    "apostrophe": "git+https://github.com/apostrophecms/apostrophe.git",
+    "@apostrophecms/redirect": "git+https://github.com/apostrophecms/redirect.git"
+  }
+}


### PR DESCRIPTION
[PRO-4691](https://linear.app/apostrophecms/issue/PRO-4691/redirect-to-other-locales-redirect-module)

## Summary

* Allow to redirect to locales that are not the current one by storing (when the target is an internal page is another locale) the `targetLocale` in the redirect document. This way we can update the `req` object based on this information to get the right page relationship, whatever the current locale.
* Add tests for external redirects, internal redirects, and internal redirects to other locales.

* Add a query builder and extend the find method to only get redirects that have external redirect or internal redirect to the current locale.
⚠️ I don't think this behavior is viable since it could bring BC for users using the find method of the redirect method. Moreover it will feel unnatural for users to not be able to see all redirects in all locales since they aren't localized..
For this point I think that we should wait and design a way to properly make it work with relationships. We might need that later in another context.
So I would remove the part that extend the find method and the query builder for now, WDYT?

## What are the specific steps to test this change?

You should be able to redirect a page in `fr` to a page in `en` using internal redirects (relationship will be retrieved based on its locale).

## What kind of change does this PR introduce?

- [X] Bug fix
- [] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [X] Related tests have been updated

