### PR TITLE
adds statusCode projection

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## UNRELEASED
 
 * Bug fix to properly migrate older redirects missing a `targetLocale` property, and to tolerate situations where this property is irrelevant or makes reference to a locale that no longer exists in the system.
+* Fixes permanent redirects (301) being 302 because `statusCode` of the redirects were never fetched.
 
 ## 1.4.0 (2024-02-23)
 

--- a/index.js
+++ b/index.js
@@ -189,7 +189,8 @@ module.exports = {
                 externalUrl: 1,
                 urlType: 1,
                 ignoreQueryString: 1,
-                forwardQueryString: 1
+                forwardQueryString: 1,
+                statusCode: 1
               })
               .toArray();
 


### PR DESCRIPTION
[PRO-5716](https://linear.app/apostrophecms/issue/PRO-5716/redirect-issue-external-link-type-redirects-going-to-302-instead-of)

## Summary

Fix the fact that 301 redirects where 302. `statusCode` were undefined so 302 by default.

## What are the specific steps to test this change?

Selecting 301 redirects actually should redirect with 301 status and not 302.

## What kind of change does this PR introduce?

- [X] Bug fix
- [ ] New feature
- [ ] Refactor
- [ ] Documentation
- [ ] Build-related changes
- [ ] Other

## Make sure the PR fulfills these requirements:

- [X] It includes a) the existing issue ID being resolved, b) a convincing reason for adding this feature, or c) a clear description of the bug it resolves
- [X] The changelog is updated
- [ ] Related documentation has been updated
- [ ] Related tests have been updated
