### PR TITLE
PRO-8168: UTF8 characters in redirects should match as expected

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,8 +20,8 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        node-version: [18, 20]
-        mongodb-version: ['4.4', '5.0', '6.0']
+        node-version: [20, 22, 24]
+        mongodb-version: ['6.0', '7.0', '8.0']
 
     # Steps represent a sequence of tasks that will be executed as part of the job
     steps:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # Changelog
 
+## UNRELEASED
+
+* Bug fix: UTF8 URLs now match properly. For instance, redirects containing Thai characters work as expected. Editors can paste them naturally (without hand-escaping them first) and the redirect module will correctly decode the URL received from Express before attempting to match it to a redirect.
+
 ## 1.4.2 (2024-10-03)
 
 * Updates translations strings

--- a/index.js
+++ b/index.js
@@ -175,9 +175,14 @@ module.exports = {
           }
 
           try {
-            const slug = req.originalUrl;
-            const [ pathOnly, queryString ] = slug.split('?');
-
+            let slug = req.originalUrl;
+            let [ pathOnly, queryString ] = slug.split('?');
+            pathOnly = pathOnly.split('/').map(decodeURIComponent).join('/');
+            if (queryString) {
+              slug = `${pathOnly}?${queryString}`;
+            } else {
+              slug = pathOnly;
+            }
             const results = await self
               .find(req, { $or: [ { redirectSlug: slug }, { redirectSlug: pathOnly } ] })
               .currentLocaleTarget(false)

--- a/index.js
+++ b/index.js
@@ -178,7 +178,7 @@ module.exports = {
             let slug = req.originalUrl;
             let [ pathOnly, queryString ] = slug.split('?');
             pathOnly = pathOnly.split('/').map(decodeURIComponent).join('/');
-            if (queryString) {
+            if (queryString !== undefined) {
               slug = `${pathOnly}?${queryString}`;
             } else {
               slug = pathOnly;

--- a/test/index.js
+++ b/test/index.js
@@ -41,6 +41,21 @@ describe('@apostrophecms/redirect', function () {
     assert.equal(redirected, '<title>page 2</title>\n');
   });
 
+  it('should allow to redirect to external URLs when the initial slug is UTF8', async function() {
+    const req = apos.task.getReq();
+    const instance = redirectModule.newInstance();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'external redirect',
+      urlType: 'external',
+      redirectSlug: '/page-✅',
+      externalUrl: 'http://localhost:3000/page-2'
+    });
+    const redirected = await apos.http.get('http://localhost:3000/page-1-✅');
+
+    assert.equal(redirected, '<title>page 2</title>\n');
+  });
+
   it('should allow to redirect to internal pages', async function() {
     const req = apos.task.getReq();
     const instance = redirectModule.newInstance();
@@ -86,6 +101,12 @@ async function insertPages(apos) {
     ...pageInstance,
     title: 'page 1',
     slug: '/page-1'
+  });
+  // For utf8 tests
+  await apos.page.insert(req, '_home', 'lastChild', {
+    ...pageInstance,
+    title: 'page ✅',
+    slug: '/page-✅'
   });
   await apos.page.insert(req, '_home', 'lastChild', {
     ...pageInstance,

--- a/test/index.js
+++ b/test/index.js
@@ -51,8 +51,41 @@ describe('@apostrophecms/redirect', function () {
       redirectSlug: '/page-✅',
       externalUrl: 'http://localhost:3000/page-2'
     });
-    const redirected = await apos.http.get('http://localhost:3000/page-1-✅');
+    const redirected = await apos.http.get('http://localhost:3000/page-✅');
 
+    assert.equal(redirected, '<title>page 2</title>\n');
+  });
+
+  it('query string matters by default', async function() {
+    const req = apos.task.getReq();
+    const instance = redirectModule.newInstance();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'external redirect',
+      urlType: 'external',
+      redirectSlug: '/page-✅',
+      externalUrl: 'http://localhost:3000/page-2'
+    });
+    try {
+      await apos.http.get('http://localhost:3000/page-✅?whatever');
+      assert(false);
+    } catch (e) {
+      // good, should 404
+    }
+  });
+
+  it('query string can optionally be ignored', async function() {
+    const req = apos.task.getReq();
+    const instance = redirectModule.newInstance();
+    await redirectModule.insert(req, {
+      ...instance,
+      title: 'external redirect',
+      urlType: 'external',
+      redirectSlug: '/page-✅',
+      externalUrl: 'http://localhost:3000/page-2',
+      ignoreQueryString: true
+    });
+    const redirected = await apos.http.get('http://localhost:3000/page-✅?whatever');
     assert.equal(redirected, '<title>page 2</title>\n');
   });
 
@@ -101,12 +134,6 @@ async function insertPages(apos) {
     ...pageInstance,
     title: 'page 1',
     slug: '/page-1'
-  });
-  // For utf8 tests
-  await apos.page.insert(req, '_home', 'lastChild', {
-    ...pageInstance,
-    title: 'page ✅',
-    slug: '/page-✅'
   });
   await apos.page.insert(req, '_home', 'lastChild', {
     ...pageInstance,


### PR DESCRIPTION
TIFA (Today I Finally Admitted): web browsers always percent-escape Unicode characters in the path, and express delivers them to the application in their escaped form. Our redirect module needs to take this into account by undoing the escaping before matching with user-entered paths.